### PR TITLE
Use legacy Openssl provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   },
   "contributors": [
     {
+      "name": "Logan Houp",
+      "email": "lhoup@2060digital.com",
+      "url": "https://2060digital.com"
+    },
+    {
       "name": "Alexander Feiglstorfer",
       "email": "af@storyblok.com",
       "url": "https://www.storyblok.com/"
@@ -18,13 +23,13 @@
       "url": "https://www.storyblok.com/"
     }
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
-    "dev": "npm run serve",
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider npm run serve",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
+    "lint": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service lint"
   },
   "dependencies": {
     "vue": "^2.6.14"


### PR DESCRIPTION
Node v18 introduced a backwards incompatible change for this boilerplate's dependencies. This flag instructs Node to use the legacy OpenSSL provider for newer versions of Node as a workaround until someone is available to update this project's dependencies.

This closes #14.